### PR TITLE
New report_object_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.0.28 (2017-07-09)
+- Updated generate_field_data to support new report object type
+
 # 0.0.27 (2016-09-06)
 - Added LVM attributes for version 2.02.161(2)
 - Added LVM attributes for version 2.02.158(2)

--- a/bin/generate_field_data
+++ b/bin/generate_field_data
@@ -119,7 +119,7 @@ File.readlines(lvm_source + COLUMNS_FILE).each do |line|
   # dropped when passing column names as arguments as well, but i found a few
   # with issues (seg_start).
   case app
-  when "LVS", "LVSINFOSTATUS"
+  when "LVS", "LVSINFOSTATUS", "LVSSTATUS"
     method.sub!(%r{^lv_}, '')
   when "SEGS"
     method.sub!(%r{^seg_}, '')
@@ -141,7 +141,7 @@ File.readlines(lvm_source + COLUMNS_FILE).each do |line|
   }
 
   case app
-  when "LVS", "LVSINFOSTATUS"
+  when "LVS", "LVSINFOSTATUS", "LVSSTATUS"
     lvs << attribute
   when "SEGS"
     lvssegs << attribute


### PR DESCRIPTION
Hi,

 I found that https://github.com/sensu-plugins/sensu-plugins-lvm Sensu plugin stopped to work.
 It looks like that lvs.yaml was missing some attributes, which was not removed by upstream (LVM2), but upstream introduced new report_object_type (LVSSTATUS).
 Commit fix'es update generate_field_data script to add again all fields.

Aivaras