### PR TITLE
Update LVM2 Repository URL in update script

### DIFF
--- a/update-lvm.sh
+++ b/update-lvm.sh
@@ -26,7 +26,7 @@
 #   `next` branch -- NOT MASTER!**
 #
 
-repo_url=git://git.fedorahosted.org/git/lvm2.git
+repo_url=git://sourceware.org/git/lvm2.git
 refs=refs/heads/master:refs/remotes/origin/master
 pattern=v2_02_*
 git_dir=lvm2/.git


### PR DESCRIPTION
As of https://www.sourceware.org/lvm2/ the source code is stored in git and can be accessed with 
git clone git://sourceware.org/git/lvm2.git